### PR TITLE
update partners for CloudBrew 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@
   <!-- Partners Section -->
   <section class="mb-0" id="partners">
     <div class="container">
-      <h2 class="text-center text-uppercase">Last year's partners</h2>
+      <h2 class="text-center text-uppercase">This year's partners</h2>
       <hr class="star-dark mb-5">
       <p class="text-center lead">CloudBrew would not be possible without our partners. Thanks!</p>
 
@@ -261,29 +261,8 @@
 
         <div class="container">
           <div class="row justify-content-center">
-            <div class="col-12 col-md-4">
-              <a href="https://www.ae.be/"><img src="img/sponsors/logo-ae.jpg" class="sponsor-platinum" /></a>
-            </div>
-            <div class="col-12 col-md-4">
-               <a href="https://www.axxes.com/"><img src="img/sponsors/logo-axxes.jpg" class="sponsor-platinum" /></a>
-            </div>
-            <div class="col-12 col-md-4">
-              <a href="https://www.cegeka.com/"><img src="img/sponsors/logo-cegeka.png" class="sponsor-platinum" /></a>
-            </div>
-            <div class="col-12 col-md-4">
+             <div class="col-12 col-md-4">
               <a href="https://www.codit.eu/"><img src="img/sponsors/logo-codit.png" class="sponsor-platinum" /></a>
-            </div>
-            <div class="col-12 col-md-4">
-              <a href="https://www.delaware.pro/"><img src="img/sponsors/logo-delaware.png" class="sponsor-platinum" /></a>
-            </div>
-            <div class="col-12 col-md-4">
-              <a href="https://www.inetum.com/"><img src="img/sponsors/logo-inetum.png" class="sponsor-platinum" /></a>
-            </div>
-            <div class="col-12 col-md-4">
-              <a href="https://www.microsoft.be/"><img src="img/sponsors/logo-microsoft.jpg" class="sponsor-platinum" /></a>
-            </div>
-            <div class="col-12 col-md-4">
-              <a href="https://spikes.be/"><img src="img/sponsors/logo-spikes-2025.png" class="sponsor-platinum" /></a>
             </div>
             <div class="col-12 col-md-4">
               <a href="https://www.zure.com/"><img src="img/sponsors/logo-zure.png" class="sponsor-platinum" /></a>
@@ -343,19 +322,7 @@
 
         <div class="container">
           <div class="row justify-content-center">
-            <div class="col-6 col-md-2">              
-            </div>
-            <div class="col-6 col-md-2">
-              <a href="https://www.arxus.eu/"><img src="img/sponsors/logo-arxus.png" class="sponsor-silver" /></a>
-            </div>
-            <div class="col-6 col-md-2">
-              <a href="https://integration.team/"><img src="img/sponsors/logo-integrationteam.png" class="sponsor-silver" /></a>
-            </div>
-            <div class="col-6 col-md-2">
-              <a href="https://www.u2u.be/"><img src="img/sponsors/logo-u2u.png" class="sponsor-silver" /></a>
-                   </div>
-            <div class="col-6 col-md-2">
-            </div>
+            <div class="col-6 col-md-2"></div>
 
           </div>
         </div>


### PR DESCRIPTION
This pull request updates the "Partners" section of the `index.html` file to reflect the current year's partners and revises the display of platinum and silver partners. The most important changes are:

Partner section updates:

* Changed the section heading from "Last year's partners" to "This year's partners" to reflect the current event sponsors.

Platinum partners list:

* Updated the list of platinum partners by removing several previous sponsors and leaving only Codit and Zure as platinum partners.

Silver partners list:

* Removed all previously listed silver partners, leaving the section effectively empty except for a placeholder column.